### PR TITLE
Update package pricing and add Tron overlay

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -725,6 +725,8 @@ header p {
     transition: transform 0.3s ease, box-shadow 0.3s ease;
     box-shadow: 0 10px 20px rgba(255, 69, 0, 0.4);
     text-align: center;
+    position: relative; /* Needed for Tron overlay */
+    overflow: hidden; /* Ensure overlay stays within box */
 }
 
 /* Hover effects */
@@ -747,6 +749,40 @@ header p {
 .deluxe-package {
     background-color: rgba(128, 0, 128, 0.6); /* Transparent regal purple */
     box-shadow: 0 10px 20px rgba(128, 0, 128, 0.4);
+}
+
+/* Tron grid overlay for packages */
+.basic-package::before,
+.plus-package::before,
+.deluxe-package::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-image:
+        linear-gradient(rgba(0, 255, 255, 0.15) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255, 0, 255, 0.15) 1px, transparent 1px);
+    background-size: 50px 50px;
+    animation: grid-move 30s linear infinite;
+    z-index: 0;
+    pointer-events: none; /* Allow interaction with content */
+}
+
+.basic-package > *,
+.plus-package > *,
+.deluxe-package > * {
+    position: relative;
+    z-index: 1; /* Place content above Tron overlay */
+}
+
+/* Disclaimer styling */
+.price-disclaimer {
+    font-size: 0.9em;
+    margin-top: 20px;
+    color: #ccc;
+    font-style: italic;
 }
 
 /* Responsive adjustments for mobile screens */

--- a/website_packages.html
+++ b/website_packages.html
@@ -131,8 +131,8 @@
                 <li>Regular Site Backups</li>
                 <li>Monthly Support</li>
             </ul>
-            <p class="price with-design-fee"><strong>Price:</strong> $1695 + $79 per month</p>
-            <p class="price without-design-fee hidden"><strong>Price:</strong> $149 per month</p>
+            <p class="price with-design-fee"><strong>Price:</strong> Starting at $999 + $79 per month</p>
+            <p class="price without-design-fee hidden"><strong>Price:</strong> Starting at $199 per month</p>
             <a href="index.html#contact?package=Basic%20Package" class="add-to-cart-btn" data-package="Basic Package">Consult Us</a>
         </div>
 
@@ -146,8 +146,8 @@
                 <li>Live Chat Integration</li>
                 <li>Commercial Email Setup</li>
             </ul>
-            <p class="price with-design-fee"><strong>Price:</strong> $2495 + $89 per month</p>
-            <p class="price without-design-fee hidden"><strong>Price:</strong> $189 per month</p>
+            <p class="price with-design-fee"><strong>Price:</strong> Starting at $1695 + $99 per month</p>
+            <p class="price without-design-fee hidden"><strong>Price:</strong> Starting at $299 per month</p>
             <a href="index.html#contact?package=Plus%20Package" class="add-to-cart-btn" data-package="Plus Package">Consult Us</a>
         </div>
 
@@ -163,11 +163,12 @@
                 <li>Commercial Email Setup</li>
                 <li>Upgraded Live Chat Option</li>
             </ul>
-            <p class="price with-design-fee"><strong>Price:</strong> $3695 + $99 per month</p>
-            <p class="price without-design-fee hidden"><strong>Price:</strong> $249 per month</p>
+            <p class="price with-design-fee"><strong>Price:</strong> Starting at $2995 + $149 per month</p>
+            <p class="price without-design-fee hidden"><strong>Price:</strong> Starting at $499 per month</p>
             <a href="index.html#contact?package=Deluxe%20Package" class="add-to-cart-btn" data-package="Deluxe Package">Consult Us</a>
         </div>
     </div>
+    <p class="price-disclaimer">*Prices are starting points and subject to change. Rates reflect current market standards and we strive to beat competitor pricing.</p>
 </section>
 
 <div class="line-through"></div>


### PR DESCRIPTION
## Summary
- refresh web design package pricing and monthly rates with new starting amounts for design and non-design fee options
- note that prices are subject to change based on market standards and competitive goals
- overlay a Tron-style animated grid atop each package for a cyber aesthetic

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68955d202f3c8321a9346f57914af243