### PR TITLE
Add Instant Paid Traffic links and center section boxes

### DIFF
--- a/fb_google_ads.html
+++ b/fb_google_ads.html
@@ -52,6 +52,14 @@
 
     <div class="line-through"></div>
 
+    <div id="instant-paid-traffic" class="service-section">
+        <h2>Instant Paid Traffic</h2>
+        <p>Drive immediate visitors to your site with targeted Google and Facebook ads tailored for quick results.</p>
+        <a href="index.html#contact" class="button">Consult Us</a>
+    </div>
+
+    <div class="line-through"></div>
+
     <footer class="footer">
         <p>&copy; 2025 SaaS Productized Co.</p>
         <div class="social-icons">

--- a/script.js
+++ b/script.js
@@ -35,6 +35,8 @@ document.addEventListener("DOMContentLoaded", function () {
         };
 
         window.addEventListener("scroll", updateScrollIndicator);
+        window.addEventListener("load", updateScrollIndicator);
+        window.addEventListener("resize", updateScrollIndicator);
         updateScrollIndicator();
 
         scrollIndicator.addEventListener('click', function() {

--- a/styles.css
+++ b/styles.css
@@ -949,11 +949,22 @@ header p {
 }
 
 /* Ensure the sections have proper spacing */
-section {
+section, .service-section {
     min-height: 100px; /* Prevent collapsing */
-    padding: 20px 0;
+    padding: 20px;
     position: relative;
     z-index: 1;
+    width: 80%;
+    max-width: 1000px;
+    margin: 40px auto; /* Center sections */
+    border-radius: 8px;
+}
+
+@media (max-width: 768px) {
+    section, .service-section {
+        width: 90%;
+        margin: 20px auto;
+    }
 }
 
 /* Ensure line-through divs are visible */

--- a/website_packages.html
+++ b/website_packages.html
@@ -202,7 +202,7 @@
     <section class="instant-traffic-section">
         <h2>Instant Paid Traffic</h2>
         <p>Get instant traffic to your business website with our Google and Facebook ads options. Our digital ads experience has already driven millions in revenue to our clients' websites.</p>
-        <a href="#" class="button">Learn More</a>
+        <a href="fb_google_ads.html#instant-paid-traffic" class="button">Learn More</a>
     </section>
 <div class="line-through"></div>
     


### PR DESCRIPTION
## Summary
- Link "Instant Paid Traffic" button to FB & Google Ads page
- Add dedicated Instant Paid Traffic section with Consult Us CTA
- Center gray content boxes and improve scroll indicator behavior

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68956445d7848321bdec715fa3929beb