### PR TITLE
Add grid overlay and white backgrounds to service sections

### DIFF
--- a/artificial_intelligence.html
+++ b/artificial_intelligence.html
@@ -32,12 +32,12 @@
         }
 
         /* Service Section Styling */
-        .service-section {
-            padding: 60px 20px;
-            background-color: #111;
-            color: #fff;
-            text-align: center;
-        }
+          .service-section {
+              padding: 60px 20px;
+              background-color: #fff;
+              color: #000;
+              text-align: center;
+          }
 
         .service-section h2 {
             font-size: 2.5em;
@@ -50,14 +50,15 @@
             gap: 20px;
         }
 
-        .feature-box {
-            background-color: #222;
-            padding: 30px;
-            border-radius: 8px;
-            width: 30%;
-            box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
-            transition: transform 0.3s ease, box-shadow 0.3s ease;
-        }
+          .feature-box {
+              background-color: #fff;
+              color: #000;
+              padding: 30px;
+              border-radius: 8px;
+              width: 30%;
+              box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+              transition: transform 0.3s ease, box-shadow 0.3s ease;
+          }
 
         .feature-box:hover {
             transform: translateY(-10px);
@@ -69,11 +70,11 @@
             margin-bottom: 15px;
         }
 
-        .feature-box p {
-            font-size: 1.1em;
-            color: #ccc;
-            line-height: 1.6em;
-        }
+          .feature-box p {
+              font-size: 1.1em;
+              color: #000;
+              line-height: 1.6em;
+          }
 
         .button {
             background-color: #444;

--- a/custom_analytics.html
+++ b/custom_analytics.html
@@ -11,7 +11,7 @@
         .hero-title { font-size: 1.5em; font-weight: bold; }
         .subtitle { font-size: 1.2em; margin-top: 10px; }
         .line-through { width: 100px; height: 3px; background: #fff; margin: 15px auto; }
-        .service-section { padding: 60px 20px; background-color: #111; color: #fff; text-align: center; }
+        .service-section { padding: 60px 20px; background-color: #fff; color: #000; text-align: center; }
         .service-section h2 { font-size: 2.5em; margin-bottom: 40px; }
         .button { background-color: #444; color: #fff; padding: 15px 30px; text-align: center; border-radius: 5px; text-decoration: none; display: inline-block; margin-top: 20px; transition: background-color 0.3s ease, transform 0.3s ease; }
         .button:hover { background-color: #666; transform: translateY(-5px); }

--- a/fb_google_ads.html
+++ b/fb_google_ads.html
@@ -11,7 +11,7 @@
         .hero-title { font-size: 1.5em; font-weight: bold; }
         .subtitle { font-size: 1.2em; margin-top: 10px; }
         .line-through { width: 100px; height: 3px; background: #fff; margin: 15px auto; }
-        .service-section { padding: 60px 20px; background-color: #111; color: #fff; text-align: center; }
+        .service-section { padding: 60px 20px; background-color: #fff; color: #000; text-align: center; }
         .service-section h2 { font-size: 2.5em; margin-bottom: 40px; }
         .button { background-color: #444; color: #fff; padding: 15px 30px; text-align: center; border-radius: 5px; text-decoration: none; display: inline-block; margin-top: 20px; transition: background-color 0.3s ease, transform 0.3s ease; }
         .button:hover { background-color: #666; transform: translateY(-5px); }

--- a/google_my_business.html
+++ b/google_my_business.html
@@ -11,7 +11,7 @@
         .hero-title { font-size: 1.5em; font-weight: bold; }
         .subtitle { font-size: 1.2em; margin-top: 10px; }
         .line-through { width: 100px; height: 3px; background: #fff; margin: 15px auto; }
-        .service-section { padding: 60px 20px; background-color: #111; color: #fff; text-align: center; }
+        .service-section { padding: 60px 20px; background-color: #fff; color: #000; text-align: center; }
         .service-section h2 { font-size: 2.5em; margin-bottom: 40px; }
         .button { background-color: #444; color: #fff; padding: 15px 30px; text-align: center; border-radius: 5px; text-decoration: none; display: inline-block; margin-top: 20px; transition: background-color 0.3s ease, transform 0.3s ease; }
         .button:hover { background-color: #666; transform: translateY(-5px); }

--- a/software_dev.html
+++ b/software_dev.html
@@ -66,12 +66,12 @@
         }
 
         /* Features and Service Section Styling */
-        .features-section, .service-section {
-            padding: 60px 20px;
-            background-color: #111;
-            color: #fff;
-            text-align: center;
-        }
+          .features-section, .service-section {
+              padding: 60px 20px;
+              background-color: #fff;
+              color: #000;
+              text-align: center;
+          }
 
         .features-section h2, .service-section h2 {
             font-size: 2.5em;
@@ -84,14 +84,15 @@
             gap: 20px;
         }
 
-        .feature-box, .service-box {
-            background-color: #222;
-            padding: 30px;
-            border-radius: 8px;
-            width: 30%;
-            box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
-            transition: transform 0.3s ease, box-shadow 0.3s ease;
-        }
+          .feature-box, .service-box {
+              background-color: #fff;
+              color: #000;
+              padding: 30px;
+              border-radius: 8px;
+              width: 30%;
+              box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+              transition: transform 0.3s ease, box-shadow 0.3s ease;
+          }
 
         .feature-box:hover, .service-box:hover {
             transform: translateY(-10px);
@@ -103,11 +104,11 @@
             margin-bottom: 15px;
         }
 
-        .feature-box p, .service-box p {
-            font-size: 1.1em;
-            color: #ccc;
-            line-height: 1.6em;
-        }
+          .feature-box p, .service-box p {
+              font-size: 1.1em;
+              color: #000;
+              line-height: 1.6em;
+          }
 
         /* Button Styling */
         .button {

--- a/styles.css
+++ b/styles.css
@@ -1102,3 +1102,65 @@ div.line-through {
     color: #fff;
     font-size: 1em;
 }
+
+/* Grid overlay for content sections and boxes */
+.service-section,
+.services-section,
+.packages-section,
+.analytics-section,
+.service,
+.package,
+.service-box,
+.feature-box {
+    background-color: #fff;
+    color: #000;
+    position: relative;
+    overflow: hidden;
+}
+
+.service-section::before,
+.services-section::before,
+.packages-section::before,
+.analytics-section::before,
+.service::before,
+.package::before,
+.service-box::before,
+.feature-box::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-image:
+        linear-gradient(rgba(0, 255, 255, 0.15) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255, 0, 255, 0.15) 1px, transparent 1px);
+    background-size: 50px 50px;
+    z-index: 0;
+    pointer-events: none;
+    animation: grid-move 30s linear infinite;
+}
+
+.service-section > *,
+.services-section > *,
+.packages-section > *,
+.analytics-section > *,
+.service > *,
+.package > *,
+.service-box > *,
+.feature-box > * {
+    position: relative;
+    z-index: 1;
+}
+
+/* Ensure text is visible on white backgrounds */
+.service h3, .service p,
+.package h3, .package p, .package li,
+.service-box h3, .service-box p,
+.feature-box h3, .feature-box p,
+.service-section h2, .service-section p,
+.services-section h2, .services-section p,
+.packages-section h2, .packages-section p,
+.analytics-section h2, .analytics-section p {
+    color: #000;
+}

--- a/web3.html
+++ b/web3.html
@@ -39,12 +39,12 @@
         }
 
         /* Service Section Styling */
-        .service-section {
-            padding: 60px 20px;
-            background-color: #111;
-            color: #fff;
-            text-align: center;
-        }
+          .service-section {
+              padding: 60px 20px;
+              background-color: #fff;
+              color: #000;
+              text-align: center;
+          }
 
         .service-section h2 {
             font-size: 2.5em;


### PR DESCRIPTION
## Summary
- Overlay moving grid on service, package, and feature boxes across the site
- Switch content boxes and sections to white backgrounds with dark text
- Update individual pages to adopt new white grid-styled service sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68956621205c8321b37d60827c251350