### PR TITLE
Revert service page colors and fix map centering

### DIFF
--- a/artificial_intelligence.html
+++ b/artificial_intelligence.html
@@ -32,12 +32,12 @@
         }
 
         /* Service Section Styling */
-          .service-section {
-              padding: 60px 20px;
-              background-color: #fff;
-              color: #000;
-              text-align: center;
-          }
+        .service-section {
+            padding: 60px 20px;
+            background-color: #111;
+            color: #fff;
+            text-align: center;
+        }
 
         .service-section h2 {
             font-size: 2.5em;
@@ -50,15 +50,14 @@
             gap: 20px;
         }
 
-          .feature-box {
-              background-color: #fff;
-              color: #000;
-              padding: 30px;
-              border-radius: 8px;
-              width: 30%;
-              box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
-              transition: transform 0.3s ease, box-shadow 0.3s ease;
-          }
+            .feature-box {
+                background-color: #222;
+                padding: 30px;
+                border-radius: 8px;
+                width: 30%;
+                box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+                transition: transform 0.3s ease, box-shadow 0.3s ease;
+            }
 
         .feature-box:hover {
             transform: translateY(-10px);
@@ -70,11 +69,11 @@
             margin-bottom: 15px;
         }
 
-          .feature-box p {
-              font-size: 1.1em;
-              color: #000;
-              line-height: 1.6em;
-          }
+            .feature-box p {
+                font-size: 1.1em;
+                color: #ccc;
+                line-height: 1.6em;
+            }
 
         .button {
             background-color: #444;

--- a/custom_analytics.html
+++ b/custom_analytics.html
@@ -11,7 +11,7 @@
         .hero-title { font-size: 1.5em; font-weight: bold; }
         .subtitle { font-size: 1.2em; margin-top: 10px; }
         .line-through { width: 100px; height: 3px; background: #fff; margin: 15px auto; }
-        .service-section { padding: 60px 20px; background-color: #fff; color: #000; text-align: center; }
+          .service-section { padding: 60px 20px; background-color: #111; color: #fff; text-align: center; }
         .service-section h2 { font-size: 2.5em; margin-bottom: 40px; }
         .button { background-color: #444; color: #fff; padding: 15px 30px; text-align: center; border-radius: 5px; text-decoration: none; display: inline-block; margin-top: 20px; transition: background-color 0.3s ease, transform 0.3s ease; }
         .button:hover { background-color: #666; transform: translateY(-5px); }

--- a/fb_google_ads.html
+++ b/fb_google_ads.html
@@ -11,7 +11,7 @@
         .hero-title { font-size: 1.5em; font-weight: bold; }
         .subtitle { font-size: 1.2em; margin-top: 10px; }
         .line-through { width: 100px; height: 3px; background: #fff; margin: 15px auto; }
-        .service-section { padding: 60px 20px; background-color: #fff; color: #000; text-align: center; }
+        .service-section { padding: 60px 20px; background-color: #111; color: #fff; text-align: center; }
         .service-section h2 { font-size: 2.5em; margin-bottom: 40px; }
         .button { background-color: #444; color: #fff; padding: 15px 30px; text-align: center; border-radius: 5px; text-decoration: none; display: inline-block; margin-top: 20px; transition: background-color 0.3s ease, transform 0.3s ease; }
         .button:hover { background-color: #666; transform: translateY(-5px); }

--- a/google_my_business.html
+++ b/google_my_business.html
@@ -11,7 +11,7 @@
         .hero-title { font-size: 1.5em; font-weight: bold; }
         .subtitle { font-size: 1.2em; margin-top: 10px; }
         .line-through { width: 100px; height: 3px; background: #fff; margin: 15px auto; }
-        .service-section { padding: 60px 20px; background-color: #fff; color: #000; text-align: center; }
+        .service-section { padding: 60px 20px; background-color: #111; color: #fff; text-align: center; }
         .service-section h2 { font-size: 2.5em; margin-bottom: 40px; }
         .button { background-color: #444; color: #fff; padding: 15px 30px; text-align: center; border-radius: 5px; text-decoration: none; display: inline-block; margin-top: 20px; transition: background-color 0.3s ease, transform 0.3s ease; }
         .button:hover { background-color: #666; transform: translateY(-5px); }

--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
             src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d11877.425176039964!2d-87.6253308!3d41.90669885!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x880fd35a4496d0ed%3A0xace21a6c41f409f4!2sGold%20Coast%2C%20Chicago%2C%20IL%2060610!5e0!3m2!1sen!2sus!4v1728264141626!5m2!1sen!2sus" 
             width="400" 
             height="250" 
-            style="border:0; margin: 0 auto;" 
+            style="border:0; display:block; margin: 0 auto;"
             allowfullscreen="" 
             loading="lazy" 
             referrerpolicy="no-referrer-when-downgrade">

--- a/software_dev.html
+++ b/software_dev.html
@@ -68,8 +68,8 @@
         /* Features and Service Section Styling */
           .features-section, .service-section {
               padding: 60px 20px;
-              background-color: #fff;
-              color: #000;
+              background-color: #111;
+              color: #fff;
               text-align: center;
           }
 
@@ -85,8 +85,7 @@
         }
 
           .feature-box, .service-box {
-              background-color: #fff;
-              color: #000;
+              background-color: #222;
               padding: 30px;
               border-radius: 8px;
               width: 30%;
@@ -106,7 +105,7 @@
 
           .feature-box p, .service-box p {
               font-size: 1.1em;
-              color: #000;
+              color: #ccc;
               line-height: 1.6em;
           }
 

--- a/styles.css
+++ b/styles.css
@@ -1112,8 +1112,6 @@ div.line-through {
 .package,
 .service-box,
 .feature-box {
-    background-color: #fff;
-    color: #000;
     position: relative;
     overflow: hidden;
 }
@@ -1151,16 +1149,4 @@ div.line-through {
 .feature-box > * {
     position: relative;
     z-index: 1;
-}
-
-/* Ensure text is visible on white backgrounds */
-.service h3, .service p,
-.package h3, .package p, .package li,
-.service-box h3, .service-box p,
-.feature-box h3, .feature-box p,
-.service-section h2, .service-section p,
-.services-section h2, .services-section p,
-.packages-section h2, .packages-section p,
-.analytics-section h2, .analytics-section p {
-    color: #000;
 }

--- a/web3.html
+++ b/web3.html
@@ -41,8 +41,8 @@
         /* Service Section Styling */
           .service-section {
               padding: 60px 20px;
-              background-color: #fff;
-              color: #000;
+              background-color: #111;
+              color: #fff;
               text-align: center;
           }
 


### PR DESCRIPTION
## Summary
- Restore dark gray backgrounds on service pages while keeping the cyan and magenta grid overlay.
- Remove hard-coded white styles from global overlay to bring back original package colors.
- Correct Google Map iframe centering on the homepage.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689568e1c3f48321bbacc79403b80310