### PR TITLE
Improve scroll indicator behavior

### DIFF
--- a/script.js
+++ b/script.js
@@ -25,11 +25,16 @@ document.addEventListener("DOMContentLoaded", function () {
             const scrollTop = window.scrollY;
             const viewportHeight = window.innerHeight;
             const docHeight = document.documentElement.scrollHeight;
-            const threshold = 100;
+            const threshold = Math.min(100, docHeight - viewportHeight - 1);
+
+            if (docHeight <= viewportHeight) {
+                scrollText.innerText = "Scroll Down";
+                return;
+            }
 
             if (scrollTop + viewportHeight >= docHeight - threshold) {
                 scrollText.innerText = "Scroll Up";
-            } else if (scrollTop <= threshold) {
+            } else {
                 scrollText.innerText = "Scroll Down";
             }
         };
@@ -40,12 +45,21 @@ document.addEventListener("DOMContentLoaded", function () {
         updateScrollIndicator();
 
         scrollIndicator.addEventListener('click', function() {
-            const about = document.querySelector('.about-section');
-            if (about) {
-                window.scrollTo({
-                    top: about.offsetTop,
-                    behavior: 'smooth'
-                });
+            const scrollTop = window.scrollY;
+            const viewportHeight = window.innerHeight;
+            const docHeight = document.documentElement.scrollHeight;
+            const threshold = Math.min(100, docHeight - viewportHeight - 1);
+
+            if (docHeight > viewportHeight && scrollTop + viewportHeight >= docHeight - threshold) {
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+            } else {
+                const about = document.querySelector('.about-section');
+                if (about) {
+                    window.scrollTo({
+                        top: about.offsetTop,
+                        behavior: 'smooth'
+                    });
+                }
             }
         });
     }


### PR DESCRIPTION
## Summary
- ensure scroll indicator defaults to "Scroll Down" and only switches to "Scroll Up" near page end
- clicking indicator at bottom now scrolls smoothly to the top

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895723b373c832180b031de689cbb33