### PR TITLE
Fix scroll indicator behavior and center about page map

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,14 +100,12 @@
 
 <!-- Embedded Google Map Section -->
 <div class="map-section">
-    <div class="container map-container" style="text-align: center; padding: 20px;">
-        <iframe 
-            src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d11877.425176039964!2d-87.6253308!3d41.90669885!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x880fd35a4496d0ed%3A0xace21a6c41f409f4!2sGold%20Coast%2C%20Chicago%2C%20IL%2060610!5e0!3m2!1sen!2sus!4v1728264141626!5m2!1sen!2sus" 
-            width="400" 
-            height="250" 
-            style="border:0; display:block; margin: 0 auto;"
-            allowfullscreen="" 
-            loading="lazy" 
+    <div class="container map-container">
+        <iframe
+            src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d11877.425176039964!2d-87.6253308!3d41.90669885!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x880fd35a4496d0ed%3A0xace21a6c41f409f4!2sGold%20Coast%2C%20Chicago%2C%20IL%2060610!5e0!3m2!1sen!2sus!4v1728264141626!5m2!1sen!2sus"
+            class="about-map"
+            allowfullscreen=""
+            loading="lazy"
             referrerpolicy="no-referrer-when-downgrade">
         </iframe>
     </div>

--- a/script.js
+++ b/script.js
@@ -21,22 +21,22 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     if (scrollIndicator && scrollText) {
-        const updateScrollIndicator = () => {
-            const scrollTop = window.scrollY;
-            const viewportHeight = window.innerHeight;
-            const docHeight = document.documentElement.scrollHeight;
-            const threshold = Math.min(100, docHeight - viewportHeight - 1);
+        // Detect if the user has reached (or is very close to) the bottom of the page
+        const isAtBottom = () => {
+            const scrollPosition = window.pageYOffset || document.documentElement.scrollTop;
+            const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+            const scrollHeight = document.documentElement.scrollHeight;
+            return scrollPosition + viewportHeight >= scrollHeight - 5; // allow small threshold
+        };
 
-            if (docHeight <= viewportHeight) {
+        const updateScrollIndicator = () => {
+            const docHeight = document.documentElement.scrollHeight;
+            if (docHeight <= window.innerHeight + 5) {
                 scrollText.innerText = "Scroll Down";
                 return;
             }
 
-            if (scrollTop + viewportHeight >= docHeight - threshold) {
-                scrollText.innerText = "Scroll Up";
-            } else {
-                scrollText.innerText = "Scroll Down";
-            }
+            scrollText.innerText = isAtBottom() ? "Scroll Up" : "Scroll Down";
         };
 
         window.addEventListener("scroll", updateScrollIndicator);
@@ -45,20 +45,12 @@ document.addEventListener("DOMContentLoaded", function () {
         updateScrollIndicator();
 
         scrollIndicator.addEventListener('click', function() {
-            const scrollTop = window.scrollY;
-            const viewportHeight = window.innerHeight;
-            const docHeight = document.documentElement.scrollHeight;
-            const threshold = Math.min(100, docHeight - viewportHeight - 1);
-
-            if (docHeight > viewportHeight && scrollTop + viewportHeight >= docHeight - threshold) {
+            if (isAtBottom()) {
                 window.scrollTo({ top: 0, behavior: 'smooth' });
             } else {
                 const about = document.querySelector('.about-section');
                 if (about) {
-                    window.scrollTo({
-                        top: about.offsetTop,
-                        behavior: 'smooth'
-                    });
+                    about.scrollIntoView({ behavior: 'smooth' });
                 }
             }
         });

--- a/styles.css
+++ b/styles.css
@@ -228,6 +228,21 @@ body::before {
     }
 }
 
+/* Map Section */
+.map-container {
+    padding: 20px;
+    text-align: center;
+}
+
+.about-map {
+    width: 100%;
+    max-width: 400px;
+    height: 250px;
+    border: 0;
+    display: block;
+    margin: 0 auto;
+}
+
 /* Section Styling */
 section {
     padding: 60px 20px;


### PR DESCRIPTION
## Summary
- Improve scroll indicator logic to correctly show 'Scroll Up' when users reach the bottom and scroll back to top when clicked
- Center and constrain Google Map in About section for consistent display across screen sizes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689573b34e488321acb461587121abd1