### PR TITLE
Update scroll indicator to switch direction at page bottom

### DIFF
--- a/script.js
+++ b/script.js
@@ -24,7 +24,7 @@ document.addEventListener("DOMContentLoaded", function () {
         const shouldScrollUp = () => {
             const scrollTop = window.scrollY || document.documentElement.scrollTop;
             const scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
-            return scrollTop >= scrollHeight * 0.75;
+            return scrollTop >= scrollHeight - 5;
         };
 
         const updateScrollIndicator = () => {
@@ -32,10 +32,13 @@ document.addEventListener("DOMContentLoaded", function () {
             const scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
 
             if (scrollTop <= 0) {
+                scrollIndicator.classList.remove('scroll-up');
                 scrollText.innerText = "Scroll Down";
-            } else if (scrollTop >= scrollHeight * 0.75) {
+            } else if (scrollTop >= scrollHeight - 5) {
+                scrollIndicator.classList.add('scroll-up');
                 scrollText.innerText = "Scroll Up";
             } else {
+                scrollIndicator.classList.remove('scroll-up');
                 scrollText.innerText = "Scroll Down";
             }
         };

--- a/styles.css
+++ b/styles.css
@@ -228,6 +228,19 @@ body::before {
     }
 }
 
+@keyframes scroll-up {
+    0% {
+        top: 18px;
+    }
+    100% {
+        top: 5px;
+    }
+}
+
+.scroll-indicator.scroll-up .mouse-icon::before {
+    animation: scroll-up 1.5s infinite;
+}
+
 /* Map Section */
 .map-container {
     padding: 20px;


### PR DESCRIPTION
## Summary
- Ensure scroll indicator text and mouse animation change to "Scroll Up" when reaching the bottom of the page.
- Reverse mouse icon animation and toggle direction class when scrolling.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68957d2ff7c88321a4ef03e385d6819b