### PR TITLE
feat: add global scroll indicator

### DIFF
--- a/artificial_intelligence.html
+++ b/artificial_intelligence.html
@@ -191,6 +191,12 @@
 
     <div class="line-through"></div>
 
+    <!-- Scroll Indicator -->
+    <div class="scroll-indicator" id="scroll-indicator">
+        <span>Scroll Down</span>
+        <div class="mouse-icon"></div>
+    </div>
+
     <!-- Footer -->
     <footer class="footer">
         <p>&copy; 2025 SaaS Productized Co.</p>

--- a/custom_analytics.html
+++ b/custom_analytics.html
@@ -52,6 +52,12 @@
 
     <div class="line-through"></div>
 
+    <!-- Scroll Indicator -->
+    <div class="scroll-indicator" id="scroll-indicator">
+        <span>Scroll Down</span>
+        <div class="mouse-icon"></div>
+    </div>
+
     <footer class="footer">
         <p>&copy; 2025 SaaS Productized Co.</p>
         <div class="social-icons">

--- a/fb_google_ads.html
+++ b/fb_google_ads.html
@@ -60,6 +60,12 @@
 
     <div class="line-through"></div>
 
+    <!-- Scroll Indicator -->
+    <div class="scroll-indicator" id="scroll-indicator">
+        <span>Scroll Down</span>
+        <div class="mouse-icon"></div>
+    </div>
+
     <footer class="footer">
         <p>&copy; 2025 SaaS Productized Co.</p>
         <div class="social-icons">

--- a/google_my_business.html
+++ b/google_my_business.html
@@ -52,6 +52,12 @@
 
     <div class="line-through"></div>
 
+    <!-- Scroll Indicator -->
+    <div class="scroll-indicator" id="scroll-indicator">
+        <span>Scroll Down</span>
+        <div class="mouse-icon"></div>
+    </div>
+
     <footer class="footer">
         <p>&copy; 2025 SaaS Productized Co.</p>
         <div class="social-icons">

--- a/script.js
+++ b/script.js
@@ -24,7 +24,7 @@ document.addEventListener("DOMContentLoaded", function () {
         const shouldScrollUp = () => {
             const scrollTop = window.scrollY || document.documentElement.scrollTop;
             const scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
-            return scrollTop >= scrollHeight - 5;
+            return scrollTop >= scrollHeight * 0.75;
         };
 
         const updateScrollIndicator = () => {
@@ -34,7 +34,7 @@ document.addEventListener("DOMContentLoaded", function () {
             if (scrollTop <= 0) {
                 scrollIndicator.classList.remove('scroll-up');
                 scrollText.innerText = "Scroll Down";
-            } else if (scrollTop >= scrollHeight - 5) {
+            } else if (scrollTop >= scrollHeight * 0.75) {
                 scrollIndicator.classList.add('scroll-up');
                 scrollText.innerText = "Scroll Up";
             } else {
@@ -55,6 +55,8 @@ document.addEventListener("DOMContentLoaded", function () {
                 const about = document.querySelector('.about-section');
                 if (about) {
                     about.scrollIntoView({ behavior: 'smooth' });
+                } else {
+                    window.scrollBy({ top: window.innerHeight, behavior: 'smooth' });
                 }
             }
         });

--- a/software_dev.html
+++ b/software_dev.html
@@ -225,6 +225,12 @@
 
     <div class="line-through"></div>
 
+    <!-- Scroll Indicator -->
+    <div class="scroll-indicator" id="scroll-indicator">
+        <span>Scroll Down</span>
+        <div class="mouse-icon"></div>
+    </div>
+
     <!-- Footer -->
     <footer class="footer">
         <p>&copy; 2025 SaaS Productized Co.</p>
@@ -240,11 +246,6 @@
             </a>
         </div>
     </footer>
-
-    <script src="script.js"></script>
-</body>
-</html>
-
 
     <script src="script.js"></script>
 </body>

--- a/web3.html
+++ b/web3.html
@@ -277,7 +277,13 @@
 
     <div class="line-through"></div>
 
-     <!-- Footer -->
+    <!-- Scroll Indicator -->
+    <div class="scroll-indicator" id="scroll-indicator">
+        <span>Scroll Down</span>
+        <div class="mouse-icon"></div>
+    </div>
+
+    <!-- Footer -->
     <footer class="footer">
         <p>&copy; 2025 SaaS Productized Co.</p>
         <div class="social-icons">


### PR DESCRIPTION
## Summary
- show scroll indicator on every page
- flip to "Scroll Up" after 75% scroll and provide fallback when no about section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689581a3b1548321aa7acfcba7834967