### PR TITLE
Fix scroll indicator animation and restore ads page mouse indicator

### DIFF
--- a/fb_google_ads.html
+++ b/fb_google_ads.html
@@ -42,6 +42,12 @@
         </h1>
     </div>
 
+    <!-- Scroll Indicator -->
+    <div class="scroll-indicator" id="scroll-indicator">
+        <span>Scroll Down</span>
+        <div class="mouse-icon"></div>
+    </div>
+
     <div class="line-through"></div>
 
     <div class="service-section">
@@ -59,12 +65,6 @@
     </div>
 
     <div class="line-through"></div>
-
-    <!-- Scroll Indicator -->
-    <div class="scroll-indicator" id="scroll-indicator">
-        <span>Scroll Down</span>
-        <div class="mouse-icon"></div>
-    </div>
 
     <footer class="footer">
         <p>&copy; 2025 SaaS Productized Co.</p>

--- a/script.js
+++ b/script.js
@@ -23,18 +23,20 @@ document.addEventListener("DOMContentLoaded", function () {
     if (scrollIndicator && scrollText) {
         const shouldScrollUp = () => {
             const scrollTop = window.scrollY || document.documentElement.scrollTop;
-            const scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
-            return scrollTop >= scrollHeight * 0.75;
+            const windowHeight = window.innerHeight;
+            const documentHeight = document.documentElement.scrollHeight;
+            return scrollTop + windowHeight >= documentHeight - 5;
         };
 
         const updateScrollIndicator = () => {
             const scrollTop = window.scrollY || document.documentElement.scrollTop;
-            const scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
+            const windowHeight = window.innerHeight;
+            const documentHeight = document.documentElement.scrollHeight;
 
             if (scrollTop <= 0) {
                 scrollIndicator.classList.remove('scroll-up');
                 scrollText.innerText = "Scroll Down";
-            } else if (scrollTop >= scrollHeight * 0.75) {
+            } else if (scrollTop + windowHeight >= documentHeight - 5) {
                 scrollIndicator.classList.add('scroll-up');
                 scrollText.innerText = "Scroll Up";
             } else {


### PR DESCRIPTION
## Summary
- Add scroll indicator mouse animation to the FB & Google Ads page
- Correct scroll indicator logic so animation flips to "Scroll Up" near page bottom

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689583bd4cc883218f622f4622d3bc88