### PR TITLE
Improve scroll indicator bottom detection

### DIFF
--- a/script.js
+++ b/script.js
@@ -21,22 +21,33 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     if (scrollIndicator && scrollText) {
+        // Distance from the bottom of the page (in pixels) before switching the indicator
+        const bottomThreshold = 100;
+
+        const getDocumentHeight = () => Math.max(
+            document.body.scrollHeight,
+            document.documentElement.scrollHeight,
+            document.body.offsetHeight,
+            document.documentElement.offsetHeight,
+            document.documentElement.clientHeight
+        );
+
         const shouldScrollUp = () => {
             const scrollTop = window.scrollY || document.documentElement.scrollTop;
             const windowHeight = window.innerHeight;
-            const documentHeight = document.documentElement.scrollHeight;
-            return scrollTop + windowHeight >= documentHeight - 5;
+            const documentHeight = getDocumentHeight();
+            return scrollTop + windowHeight >= documentHeight - bottomThreshold;
         };
 
         const updateScrollIndicator = () => {
             const scrollTop = window.scrollY || document.documentElement.scrollTop;
             const windowHeight = window.innerHeight;
-            const documentHeight = document.documentElement.scrollHeight;
+            const documentHeight = getDocumentHeight();
 
             if (scrollTop <= 0) {
                 scrollIndicator.classList.remove('scroll-up');
                 scrollText.innerText = "Scroll Down";
-            } else if (scrollTop + windowHeight >= documentHeight - 5) {
+            } else if (scrollTop + windowHeight >= documentHeight - bottomThreshold) {
                 scrollIndicator.classList.add('scroll-up');
                 scrollText.innerText = "Scroll Up";
             } else {


### PR DESCRIPTION
## Summary
- make scroll indicator switch to scroll-up when near bottom using a generous threshold and robust height calculation

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689585df43b88321b19df255f19f9636