### PR TITLE
Fix scroll indicator toggling at page bottom

### DIFF
--- a/script.js
+++ b/script.js
@@ -22,32 +22,22 @@ document.addEventListener("DOMContentLoaded", function () {
 
     if (scrollIndicator && scrollText) {
         // Distance from the bottom of the page (in pixels) before switching the indicator
-        const bottomThreshold = 100;
+        const bottomThreshold = 50;
 
-        const getDocumentHeight = () => Math.max(
-            document.body.scrollHeight,
-            document.documentElement.scrollHeight,
-            document.body.offsetHeight,
-            document.documentElement.offsetHeight,
-            document.documentElement.clientHeight
-        );
-
-        const shouldScrollUp = () => {
-            const scrollTop = window.scrollY || document.documentElement.scrollTop;
-            const windowHeight = window.innerHeight;
-            const documentHeight = getDocumentHeight();
+        const isAtBottom = () => {
+            const scrollTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
+            const windowHeight = window.innerHeight || document.documentElement.clientHeight;
+            const documentHeight = Math.max(document.documentElement.scrollHeight, document.body.scrollHeight);
             return scrollTop + windowHeight >= documentHeight - bottomThreshold;
         };
 
         const updateScrollIndicator = () => {
-            const scrollTop = window.scrollY || document.documentElement.scrollTop;
-            const windowHeight = window.innerHeight;
-            const documentHeight = getDocumentHeight();
+            const scrollTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
 
             if (scrollTop <= 0) {
                 scrollIndicator.classList.remove('scroll-up');
                 scrollText.innerText = "Scroll Down";
-            } else if (scrollTop + windowHeight >= documentHeight - bottomThreshold) {
+            } else if (isAtBottom()) {
                 scrollIndicator.classList.add('scroll-up');
                 scrollText.innerText = "Scroll Up";
             } else {
@@ -56,13 +46,13 @@ document.addEventListener("DOMContentLoaded", function () {
             }
         };
 
-        window.addEventListener("scroll", updateScrollIndicator);
-        window.addEventListener("load", updateScrollIndicator);
-        window.addEventListener("resize", updateScrollIndicator);
+        window.addEventListener('scroll', updateScrollIndicator, { passive: true });
+        window.addEventListener('load', updateScrollIndicator);
+        window.addEventListener('resize', updateScrollIndicator);
         updateScrollIndicator();
 
-        scrollIndicator.addEventListener('click', function() {
-            if (shouldScrollUp()) {
+        scrollIndicator.addEventListener('click', function () {
+            if (isAtBottom()) {
                 window.scrollTo({ top: 0, behavior: 'smooth' });
             } else {
                 const about = document.querySelector('.about-section');


### PR DESCRIPTION
## Summary
- improve scroll indicator logic to detect when the user reaches the bottom of any page
- switch indicator between "Scroll Down" and "Scroll Up" using cross-browser scroll checks

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68958a92048483219ef154ce0a36569d