### PR TITLE
Fix scroll indicator bottom detection

### DIFF
--- a/script.js
+++ b/script.js
@@ -25,10 +25,10 @@ document.addEventListener("DOMContentLoaded", function () {
         const bottomThreshold = 50;
 
         const isAtBottom = () => {
-            const scrollTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
+            const scrollTop = window.pageYOffset || document.documentElement.scrollTop || 0;
             const windowHeight = window.innerHeight || document.documentElement.clientHeight;
             const documentHeight = Math.max(document.documentElement.scrollHeight, document.body.scrollHeight);
-            return scrollTop + windowHeight >= documentHeight - bottomThreshold;
+            return documentHeight - (scrollTop + windowHeight) <= bottomThreshold;
         };
 
         const updateScrollIndicator = () => {


### PR DESCRIPTION
## Summary
- ensure scroll indicator switches to "scroll up" when reaching bottom of page by computing document height vs scroll position

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68960a81d6e88321b59bee3e881c5731