### PR TITLE
Fix scroll indicator bottom detection

### DIFF
--- a/script.js
+++ b/script.js
@@ -27,8 +27,13 @@ document.addEventListener("DOMContentLoaded", function () {
         const isAtBottom = () => {
             const scrollTop = window.pageYOffset || document.documentElement.scrollTop || 0;
             const windowHeight = window.innerHeight || document.documentElement.clientHeight;
-            const documentHeight = Math.max(document.documentElement.scrollHeight, document.body.scrollHeight);
-            return documentHeight - (scrollTop + windowHeight) <= bottomThreshold;
+            const documentHeight = Math.max(
+                document.documentElement.scrollHeight,
+                document.body.scrollHeight,
+                document.documentElement.offsetHeight,
+                document.body.offsetHeight
+            );
+            return scrollTop + windowHeight >= documentHeight - bottomThreshold;
         };
 
         const updateScrollIndicator = () => {


### PR DESCRIPTION
## Summary
- Improve scroll indicator logic to detect when the user reaches the bottom of the page
- Ensure scroll-up state triggers reliably across different screen sizes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896200b28248321bd8da8c8bbad6b76