### PR TITLE
Fix scroll indicator switching

### DIFF
--- a/script.js
+++ b/script.js
@@ -22,15 +22,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
     if (scrollIndicator && scrollText) {
         const hasReachedBottom = () => {
-            const scrollTop = window.pageYOffset || document.documentElement.scrollTop || 0;
-            const windowHeight = window.innerHeight || document.documentElement.clientHeight;
-            const documentHeight = Math.max(
-                document.documentElement.scrollHeight,
-                document.body.scrollHeight,
-                document.documentElement.offsetHeight,
-                document.body.offsetHeight
-            );
-            return scrollTop + windowHeight >= documentHeight - 5; // small threshold for precision
+            return Math.ceil(window.innerHeight + window.scrollY) >= document.documentElement.scrollHeight - 1;
         };
 
         const updateScrollIndicator = () => {
@@ -46,6 +38,7 @@ document.addEventListener("DOMContentLoaded", function () {
         window.addEventListener('scroll', updateScrollIndicator, { passive: true });
         window.addEventListener('load', updateScrollIndicator);
         window.addEventListener('resize', updateScrollIndicator);
+        window.addEventListener('orientationchange', updateScrollIndicator);
         updateScrollIndicator();
 
         scrollIndicator.addEventListener('click', function () {

--- a/styles.css
+++ b/styles.css
@@ -216,10 +216,10 @@ body::before {
     top: 5px;
     left: 50%;
     transform: translateX(-50%);
-    animation: scroll 1.5s infinite;
+    animation: scroll-down 1.5s infinite;
 }
 
-@keyframes scroll {
+@keyframes scroll-down {
     0% {
         top: 5px;
     }


### PR DESCRIPTION
## Summary
- Improve bottom-of-page detection to toggle scroll indicator across screen sizes
- Add orientation change event listener for mobile support
- Refine scroll indicator CSS with distinct scroll-down and scroll-up animations

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897884432908321a442b03d58e0c0ac