### PR TITLE
feat: unify fonts across devices

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
+
 /* General Reset */
 * {
     margin: 0;
@@ -8,7 +10,7 @@
 html, body {
     height: 100%;
     max-width: 100%;
-    font-family: Arial, sans-serif;
+    font-family: 'Roboto', Arial, sans-serif;
     overflow-x: hidden;
 }
 


### PR DESCRIPTION
## Summary
- load Roboto from Google Fonts for a consistent experience across iOS and Android
- set Roboto as the default font to minimize text wrapping differences

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689966006c54832189778e7a74e0fc25