### PR TITLE
Show all web package options and add section icons

### DIFF
--- a/script.js
+++ b/script.js
@@ -138,7 +138,12 @@ document.addEventListener('DOMContentLoaded', function() {
         if (selectedPackage) {
             const packageSelect = document.getElementById('package_select');
             if (packageSelect) {
-                packageSelect.value = selectedPackage;
+                for (const option of packageSelect.options) {
+                    if (option.value.toLowerCase().startsWith(selectedPackage.toLowerCase())) {
+                        packageSelect.value = option.value;
+                        break;
+                    }
+                }
             }
         }
     }

--- a/website_packages.html
+++ b/website_packages.html
@@ -79,7 +79,7 @@
 <div class="line-through"></div>
    <!-- What You Get Section -->
 <section class="features-section">
-    <h2>What You Get With Each Quality Website</h2>
+    <h2><i class="fas fa-star"></i> What You Get With Each Quality Website</h2>
 
     <div class="features-container">
         <!-- Conversion Focused Websites -->
@@ -100,12 +100,13 @@
             <p>With a quality online presence comes added confidence for customers to do business with you, increasing the likelihood that customers come to you prepared to buy your goods or services.</p>
         </div>
     </div>
+    <a href="index.html#contact" class="add-to-cart-btn"><i class="fas fa-star"></i> Consult Us</a>
 </section>
 <div class="line-through" style="z-index: 1000"></div>
 
 <!-- Packages Section -->
 <section class="packages-section">
-    <h2>Our Web Design Packages</h2>
+    <h2><i class="fas fa-box"></i> Our Web Design Packages</h2>
     <p>Choose a plan that fits your needs best. You can opt to pay the upfront design fee and have a lower monthly fee or waive the upfront design fee for a simple monthly payment.</p>
     
     <br><br>
@@ -175,7 +176,7 @@
 
     <!-- Additional Options Section -->
     <section class="additional-options-section">
-        <h2>Additional Options & Customizations</h2>
+        <h2><i class="fas fa-star"></i> Additional Options & Customizations</h2>
         <p>Additional pages and forms can be added to any website package to suit your specific needs. Any options shown in larger packages are available in smaller packages for a fee. Please contact us for details.</p>
         <br>
         <br>
@@ -188,9 +189,12 @@
             <label for="package_select">Which Package are you interested in?</label>
             <select id="package_select" required>
                 <option value="Not Sure">Not Sure</option>
-                <option value="Basic Package">Basic Package</option>
-                <option value="Plus Package">Plus Package</option>
-                <option value="Deluxe Package">Deluxe Package</option>
+                <option value="Basic Package - With Design Fee">Basic Package - With Design Fee</option>
+                <option value="Basic Package - Without Design Fee">Basic Package - Without Design Fee</option>
+                <option value="Plus Package - With Design Fee">Plus Package - With Design Fee</option>
+                <option value="Plus Package - Without Design Fee">Plus Package - Without Design Fee</option>
+                <option value="Deluxe Package - With Design Fee">Deluxe Package - With Design Fee</option>
+                <option value="Deluxe Package - Without Design Fee">Deluxe Package - Without Design Fee</option>
             </select>
 
             <textarea id="message" placeholder="Enter your message" required></textarea>


### PR DESCRIPTION
## Summary
- Add star icons to “What You Get With Each Quality Website” and “Additional Options & Customizations” sections and provide consult button.
- Display package icon for “Our Web Design Packages” header.
- Expand contact form dropdown to list each package with and without design fees and adjust script to pre-fill new options.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a394a0de8832190def02fda32bef4