### PR TITLE
Enhance AI offerings section with icon and CTA

### DIFF
--- a/artificial_intelligence.html
+++ b/artificial_intelligence.html
@@ -165,14 +165,13 @@
         <h2><i class="fas fa-robot"></i> AI Solutions for Your Business</h2>
         <p>Harness the power of machine learning and automation to enhance decision-making, streamline operations, and unlock new opportunities.</p>
         <p>From predictive analytics to intelligent automation, our AI services are designed to help your business work smarter.</p>
-        <a href="index.html#contact" class="button"><i class="fas fa-star"></i> Consult Us</a>
     </div>
 
     <div class="line-through"></div>
 
     <!-- AI Feature Highlights -->
     <div class="service-section">
-        <h2>What We Offer</h2>
+        <h2><i class="fas fa-lightbulb"></i> What We Offer</h2>
         <div class="features-container">
             <div class="feature-box">
                 <h3><i class="fas fa-brain"></i> AI Strategy</h3>
@@ -187,6 +186,7 @@
                 <p>Transform raw data into actionable insights through advanced analytics and visualization.</p>
             </div>
         </div>
+        <a href="index.html#contact" class="button"><i class="fas fa-star"></i> Consult Us</a>
     </div>
 
     <div class="line-through"></div>


### PR DESCRIPTION
## Summary
- Add lightbulb icon to "What We Offer" heading on the Artificial Intelligence page
- Move "Consult Us" call-to-action to the end of the AI offerings section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a41d6ecc08321bee77fd97c304890