### PR TITLE
Add persistent language and chatbot buttons

### DIFF
--- a/script.js
+++ b/script.js
@@ -184,3 +184,39 @@ const revealObserver = new IntersectionObserver((entries, observer) => {
 }, revealOptions);
 
 revealSections.forEach(section => revealObserver.observe(section));
+
+// Add language toggle and chatbot buttons across the site
+document.addEventListener('DOMContentLoaded', function () {
+    // Language button with Google icon
+    const langBtn = document.createElement('button');
+    langBtn.id = 'language-btn';
+    langBtn.innerHTML = '<i class="fab fa-google"></i>';
+    document.body.appendChild(langBtn);
+
+    // Container for Google Translate widget
+    const translateDiv = document.createElement('div');
+    translateDiv.id = 'google_translate_element';
+    translateDiv.classList.add('hidden');
+    document.body.appendChild(translateDiv);
+
+    langBtn.addEventListener('click', () => {
+        translateDiv.classList.toggle('hidden');
+    });
+
+    // Chatbot button linking to ChatGPT 5
+    const chatBtn = document.createElement('a');
+    chatBtn.id = 'chatbot-btn';
+    chatBtn.href = 'https://chat.openai.com/?model=gpt-5';
+    chatBtn.target = '_blank';
+    chatBtn.innerHTML = '<i class="fas fa-comments"></i>';
+    document.body.appendChild(chatBtn);
+
+    // Load Google Translate script
+    window.googleTranslateElementInit = function() {
+        new google.translate.TranslateElement({ pageLanguage: 'en' }, 'google_translate_element');
+    };
+    const gtScript = document.createElement('script');
+    gtScript.type = 'text/javascript';
+    gtScript.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
+    document.head.appendChild(gtScript);
+});

--- a/styles.css
+++ b/styles.css
@@ -1205,3 +1205,44 @@ div.line-through {
     50% { transform: translateY(-5px); }
     100% { transform: translateY(0); }
 }
+
+/* Fixed language toggle button */
+#language-btn {
+    position: fixed;
+    top: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #444;
+    color: #fff;
+    padding: 10px 20px;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    z-index: 1000;
+}
+
+/* Google Translate widget container */
+#google_translate_element {
+    position: fixed;
+    top: 60px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1000;
+}
+
+/* Chatbot button */
+#chatbot-btn {
+    position: fixed;
+    bottom: 20px;
+    left: 20px;
+    background-color: #444;
+    color: #fff;
+    padding: 15px;
+    border-radius: 50%;
+    font-size: 24px;
+    text-decoration: none;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}


### PR DESCRIPTION
## Summary
- Add a fixed, Google-styled language toggle that loads Google Translate and stays centered at the top of all pages
- Introduce a bottom-left chatbot button linking users to ChatGPT 5 for 24/7 support
- Style new interface elements for consistent appearance across the site

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a51bd529083218064df98573a3275