### PR TITLE
Default to "Without Design Fee" on website packages page

### DIFF
--- a/script.js
+++ b/script.js
@@ -104,6 +104,9 @@ if (withDesign && withoutDesign) {
             el.classList.remove('hidden');
         });
     });
+
+    // Default to "Without Design Fee" on page load
+    withoutDesign.click();
 }
 
 // Pre-fill the package dropdown and handle 'Consult Us' button clicks

--- a/website_packages.html
+++ b/website_packages.html
@@ -131,8 +131,8 @@
 
     <!-- Pricing Option Toggle -->
     <div class="pricing-toggle">
-        <button id="with-design-fee" class="toggle-btn active">With Design Fee</button>
-        <button id="without-design-fee" class="toggle-btn">Without Design Fee</button>
+        <button id="with-design-fee" class="toggle-btn">With Design Fee</button>
+        <button id="without-design-fee" class="toggle-btn active">Without Design Fee</button>
     </div>
 
     <!-- Packages Container -->
@@ -150,8 +150,8 @@
                 <li>Regular Site Backups</li>
                 <li>Monthly Support</li>
             </ul>
-            <p class="price with-design-fee"><strong>Price:</strong> Starting at $999 + $79 per month</p>
-            <p class="price without-design-fee hidden"><strong>Price:</strong> Starting at $199 per month</p>
+            <p class="price with-design-fee hidden"><strong>Price:</strong> Starting at $999 + $79 per month</p>
+            <p class="price without-design-fee"><strong>Price:</strong> Starting at $199 per month</p>
             <a href="index.html#contact?package=Basic%20Package" class="add-to-cart-btn" data-package="Basic Package"><i class="fas fa-star"></i> Consult Us</a>
         </div>
 
@@ -165,8 +165,8 @@
                 <li>Live Chat Integration</li>
                 <li>Commercial Email Setup</li>
             </ul>
-            <p class="price with-design-fee"><strong>Price:</strong> Starting at $1695 + $99 per month</p>
-            <p class="price without-design-fee hidden"><strong>Price:</strong> Starting at $299 per month</p>
+            <p class="price with-design-fee hidden"><strong>Price:</strong> Starting at $1695 + $99 per month</p>
+            <p class="price without-design-fee"><strong>Price:</strong> Starting at $299 per month</p>
             <a href="index.html#contact?package=Plus%20Package" class="add-to-cart-btn" data-package="Plus Package"><i class="fas fa-star"></i> Consult Us</a>
         </div>
 
@@ -182,8 +182,8 @@
                 <li>Commercial Email Setup</li>
                 <li>Upgraded Live Chat Option</li>
             </ul>
-            <p class="price with-design-fee"><strong>Price:</strong> Starting at $2995 + $149 per month</p>
-            <p class="price without-design-fee hidden"><strong>Price:</strong> Starting at $499 per month</p>
+            <p class="price with-design-fee hidden"><strong>Price:</strong> Starting at $2995 + $149 per month</p>
+            <p class="price without-design-fee"><strong>Price:</strong> Starting at $499 per month</p>
             <a href="index.html#contact?package=Deluxe%20Package" class="add-to-cart-btn" data-package="Deluxe Package"><i class="fas fa-star"></i> Consult Us</a>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- Start the pricing toggle on the "Without Design Fee" option.
- Hide all "With Design Fee" prices and show "Without Design Fee" pricing by default.
- Initialize the toggle script to select the "Without Design Fee" view on page load.

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_689a5637bc2083219eb47e4de5b93129