### PR TITLE
Use Google Translate icon for language button

### DIFF
--- a/script.js
+++ b/script.js
@@ -190,10 +190,10 @@ revealSections.forEach(section => revealObserver.observe(section));
 
 // Add language toggle and chatbot buttons across the site
 document.addEventListener('DOMContentLoaded', function () {
-    // Language button with Google icon
+    // Language button with Google Translate PNG icon
     const langBtn = document.createElement('button');
     langBtn.id = 'language-btn';
-    langBtn.innerHTML = '<i class="fab fa-google"></i>';
+    langBtn.innerHTML = '<img src="IMG_1870.png" alt="Translate" />';
     document.body.appendChild(langBtn);
 
     // Container for Google Translate widget

--- a/styles.css
+++ b/styles.css
@@ -1221,6 +1221,11 @@ div.line-through {
     z-index: 1000;
 }
 
+#language-btn img {
+    width: 20px;
+    height: 20px;
+}
+
 /* Google Translate widget container */
 #google_translate_element {
     position: fixed;


### PR DESCRIPTION
## Summary
- Replace language toggle button's FontAwesome icon with repository PNG `IMG_1870.png`
- Add CSS to size the new translate icon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b4922ecac8321a407ce24431a92cc