### PR TITLE
feat: add on-site AI chat assistant

### DIFF
--- a/script.js
+++ b/script.js
@@ -190,11 +190,22 @@ revealSections.forEach(section => revealObserver.observe(section));
 
 // Add language toggle and chatbot buttons across the site
 document.addEventListener('DOMContentLoaded', function () {
+    // Container for utility buttons (language & chat)
+    const utilContainer = document.createElement('div');
+    utilContainer.id = 'utility-btn-container';
+    document.body.appendChild(utilContainer);
+
     // Language button with Google Translate PNG icon
     const langBtn = document.createElement('button');
     langBtn.id = 'language-btn';
     langBtn.innerHTML = '<img src="IMG_1870.png" alt="Translate" />';
-    document.body.appendChild(langBtn);
+    utilContainer.appendChild(langBtn);
+
+    // Chatbot toggle button
+    const chatBtn = document.createElement('button');
+    chatBtn.id = 'chatbot-btn';
+    chatBtn.innerHTML = '<i class="fas fa-comments"></i>';
+    utilContainer.appendChild(chatBtn);
 
     // Container for Google Translate widget
     const translateDiv = document.createElement('div');
@@ -206,13 +217,63 @@ document.addEventListener('DOMContentLoaded', function () {
         translateDiv.classList.toggle('hidden');
     });
 
-    // Chatbot button linking to ChatGPT 5
-    const chatBtn = document.createElement('a');
-    chatBtn.id = 'chatbot-btn';
-    chatBtn.href = 'https://chat.openai.com/?model=gpt-5';
-    chatBtn.target = '_blank';
-    chatBtn.innerHTML = '<i class="fas fa-comments"></i>';
-    document.body.appendChild(chatBtn);
+    // Chatbot window
+    const chatWidget = document.createElement('div');
+    chatWidget.id = 'chat-widget';
+    chatWidget.classList.add('hidden');
+    chatWidget.innerHTML = `
+        <div id="chat-log"></div>
+        <div id="chat-input-container">
+            <input type="text" id="chat-input" placeholder="Ask a question..." />
+            <button id="chat-send">Send</button>
+        </div>`;
+    document.body.appendChild(chatWidget);
+
+    chatBtn.addEventListener('click', () => {
+        chatWidget.classList.toggle('hidden');
+    });
+
+    async function sendChatMessage(message) {
+        const OPENAI_API_KEY = 'YOUR_OPENAI_API_KEY';
+        const response = await fetch('https://api.openai.com/v1/chat/completions', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${OPENAI_API_KEY}`
+            },
+            body: JSON.stringify({
+                model: 'gpt-3.5-turbo',
+                messages: [
+                    { role: 'system', content: 'You are an AI assistant for the SaaS Productized Co website. Answer questions about the site.' },
+                    { role: 'user', content: message }
+                ]
+            })
+        });
+        const data = await response.json();
+        return data.choices && data.choices[0] && data.choices[0].message ? data.choices[0].message.content : 'Sorry, I had trouble responding.';
+    }
+
+    function appendMessage(sender, text) {
+        const log = document.getElementById('chat-log');
+        const p = document.createElement('p');
+        p.innerHTML = `<strong>${sender}:</strong> ${text}`;
+        log.appendChild(p);
+        log.scrollTop = log.scrollHeight;
+    }
+
+    document.getElementById('chat-send').addEventListener('click', async () => {
+        const input = document.getElementById('chat-input');
+        const userText = input.value.trim();
+        if (!userText) return;
+        appendMessage('You', userText);
+        input.value = '';
+        try {
+            const reply = await sendChatMessage(userText);
+            appendMessage('AI', reply);
+        } catch (e) {
+            appendMessage('AI', 'There was an error contacting the assistant.');
+        }
+    });
 
     // Load Google Translate script
     window.googleTranslateElementInit = function() {

--- a/styles.css
+++ b/styles.css
@@ -1207,45 +1207,80 @@ div.line-through {
 }
 
 /* Fixed language toggle button */
-#language-btn {
+#utility-btn-container {
     position: fixed;
-    top: 10px;
-    left: 50%;
-    transform: translateX(-50%);
-    background: transparent;
-    padding: 0;
-    border: none;
-    cursor: pointer;
+    bottom: 20px;
+    right: 20px;
+    display: flex;
+    gap: 10px;
     z-index: 1000;
 }
 
+#language-btn,
+#chatbot-btn {
+    background-color: #444;
+    color: #fff;
+    border: none;
+    border-radius: 50%;
+    width: 50px;
+    height: 50px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    text-decoration: none;
+}
+
 #language-btn img {
-    width: 30px;
-    height: 30px;
+    width: 24px;
+    height: 24px;
 }
 
 /* Google Translate widget container */
 #google_translate_element {
     position: fixed;
-    top: 60px;
-    left: 50%;
-    transform: translateX(-50%);
+    bottom: 80px;
+    right: 20px;
     z-index: 1000;
 }
 
-/* Chatbot button */
-#chatbot-btn {
+/* Chat widget */
+#chat-widget {
     position: fixed;
-    bottom: 20px;
-    left: 20px;
+    bottom: 80px;
+    right: 20px;
+    width: 300px;
+    max-height: 400px;
+    background-color: #fff;
+    color: #000;
+    border: 1px solid #ccc;
+    border-radius: 10px;
+    display: flex;
+    flex-direction: column;
+    z-index: 1000;
+}
+
+#chat-log {
+    flex: 1;
+    padding: 10px;
+    overflow-y: auto;
+}
+
+#chat-input-container {
+    display: flex;
+    border-top: 1px solid #ccc;
+}
+
+#chat-input {
+    flex: 1;
+    border: none;
+    padding: 10px;
+}
+
+#chat-send {
     background-color: #444;
     color: #fff;
-    padding: 15px;
-    border-radius: 50%;
-    font-size: 24px;
-    text-decoration: none;
-    z-index: 1000;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    border: none;
+    padding: 10px 15px;
+    cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- add bottom-right utility container with translate and chat buttons
- replace external ChatGPT link with built-in assistant using OpenAI API
- style new chat widget and translate button for cohesive placement

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b7d4bbc208321b7bdfe4fe1a5dc86