### PR TITLE
Restore utility buttons layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -195,17 +195,17 @@ document.addEventListener('DOMContentLoaded', function () {
     utilContainer.id = 'utility-btn-container';
     document.body.appendChild(utilContainer);
 
-    // Language button with Google Translate PNG icon
-    const langBtn = document.createElement('button');
-    langBtn.id = 'language-btn';
-    langBtn.innerHTML = '<img src="IMG_1870.png" alt="Translate" />';
-    utilContainer.appendChild(langBtn);
-
     // Chatbot toggle button
     const chatBtn = document.createElement('button');
     chatBtn.id = 'chatbot-btn';
     chatBtn.innerHTML = '<i class="fas fa-comments"></i>';
     utilContainer.appendChild(chatBtn);
+
+    // Language button with Google Translate PNG icon
+    const langBtn = document.createElement('button');
+    langBtn.id = 'language-btn';
+    langBtn.innerHTML = '<img src="IMG_1870.png" alt="Translate" />';
+    utilContainer.appendChild(langBtn);
 
     // Container for Google Translate widget
     const translateDiv = document.createElement('div');

--- a/styles.css
+++ b/styles.css
@@ -1210,13 +1210,12 @@ div.line-through {
 #utility-btn-container {
     position: fixed;
     bottom: 20px;
-    right: 20px;
+    left: 20px;
     display: flex;
     gap: 10px;
     z-index: 1000;
 }
 
-#language-btn,
 #chatbot-btn {
     background-color: #444;
     color: #fff;
@@ -1231,6 +1230,13 @@ div.line-through {
     text-decoration: none;
 }
 
+#language-btn {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+}
+
 #language-btn img {
     width: 24px;
     height: 24px;
@@ -1240,7 +1246,7 @@ div.line-through {
 #google_translate_element {
     position: fixed;
     bottom: 80px;
-    right: 20px;
+    left: 20px;
     z-index: 1000;
 }
 
@@ -1248,7 +1254,7 @@ div.line-through {
 #chat-widget {
     position: fixed;
     bottom: 80px;
-    right: 20px;
+    left: 20px;
     width: 300px;
     max-height: 400px;
     background-color: #fff;


### PR DESCRIPTION
## Summary
- Return chat and Google Translate buttons to bottom-left corner
- Remove gray circle from translation icon and swap button order

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b7f91794883219d03c9d5c81d9e73