### PR TITLE
Ensure chatbot remains hidden until activated

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1266,6 +1266,10 @@ div.line-through {
     z-index: 1000;
 }
 
+#chat-widget.hidden {
+    display: none;
+}
+
 #chat-log {
     flex: 1;
     padding: 10px;


### PR DESCRIPTION
## Summary
- Prevent chatbot window from appearing on page load by hiding it until user clicks the chatbot button.

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_689b8d857d248321b0e7bfea81809179