### PR TITLE
Neon glow for SaaS logo and chat icon; raise chat sign to avoid overlap

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1228,11 +1228,22 @@ div.line-through {
     justify-content: center;
     cursor: pointer;
     text-decoration: none;
+    box-shadow: 0 0 12px rgba(0, 255, 255, 0.6), 0 0 24px rgba(255, 0, 255, 0.45);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+#chatbot-btn i {
+    text-shadow: 0 0 6px rgba(0, 255, 255, 0.9), 0 0 12px rgba(255, 0, 255, 0.8);
+}
+
+#chatbot-btn:hover {
+    transform: translateY(-2px) scale(1.03);
+    box-shadow: 0 0 16px rgba(0, 255, 255, 0.75), 0 0 30px rgba(255, 0, 255, 0.6);
 }
 
 #chat-sign {
     position: fixed;
-    bottom: 150px;
+    bottom: 190px;
     left: 20px;
     display: inline-flex;
     flex-direction: column;
@@ -1267,6 +1278,7 @@ div.line-through {
     width: 88px;
     height: 8px;
     margin-left: 12px;
+    margin-top: -4px;
     align-self: flex-start;
     border-radius: 999px;
     background: linear-gradient(90deg, rgba(0, 255, 255, 0.35), rgba(0, 255, 255, 0.95), rgba(255, 0, 255, 0.85));
@@ -1338,6 +1350,12 @@ div.line-through {
     50% {
         transform: rotate(var(--arrow-rotate)) scale(1.12);
     }
+}
+
+.logo-container .top-line {
+    text-shadow: 0 0 8px rgba(0, 255, 255, 0.75),
+        0 0 16px rgba(255, 0, 255, 0.55),
+        0 0 26px rgba(0, 255, 255, 0.65);
 }
 
 #language-btn {


### PR DESCRIPTION
### Motivation
- Prevent the chat sign arrow from intersecting the chat button and add a neon visual treatment to the chat UI and brand headline for stronger emphasis. 
- Apply the neon effect only to the top-line `SaaS` text (not the `Productized Co` line) and polish the chat icon hover state.

### Description
- Updated `styles.css` to add neon box-shadow and hover polish for the chat button (`#chatbot-btn`) and a text-shadow neon effect for the main logo top-line (`.logo-container .top-line`).
- Moved the chat sign upward by changing `#chat-sign` `bottom` from `150px` to `190px` and tightened the arrow spacing via `margin-top: -4px` on `.chat-sign-arrow` to avoid overlap with the chat button.
- Added an icon text-shadow rule for `#chatbot-btn i` and small transitions for smoother hover animation.

### Testing
- Launched a local static server with `python -m http.server 8000` and verified the styling by taking a full-page screenshot using a Playwright script, which produced `artifacts/saas-home.png` successfully. 
- Visual verification via the generated screenshot confirmed the neon glow and that the chat sign no longer intersects the chat icon.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981a643aedc83219cda60ba848d0d7f)