### PR TITLE
Align chat sign over chat icon and add blue neon styling to “SaaS”

### DIFF
--- a/script.js
+++ b/script.js
@@ -210,6 +210,15 @@ document.addEventListener('DOMContentLoaded', function () {
     `;
     document.body.appendChild(chatSign);
 
+    const positionChatSign = () => {
+        const chatRect = chatBtn.getBoundingClientRect();
+        const centerX = chatRect.left + (chatRect.width / 2);
+        chatSign.style.left = `${centerX}px`;
+        chatSign.style.setProperty('--chat-sign-offset', '-50%');
+    };
+    positionChatSign();
+    window.addEventListener('resize', positionChatSign);
+
     // Language button with Google Translate PNG icon
     const langBtn = document.createElement('button');
     langBtn.id = 'language-btn';

--- a/styles.css
+++ b/styles.css
@@ -1247,7 +1247,7 @@ div.line-through {
     left: 20px;
     display: inline-flex;
     flex-direction: column;
-    align-items: flex-start;
+    align-items: center;
     gap: 10px;
     padding: 0;
     border: none;
@@ -1256,6 +1256,7 @@ div.line-through {
     font-family: 'Trebuchet MS', 'Segoe UI', sans-serif;
     text-transform: uppercase;
     z-index: 1000;
+    --chat-sign-offset: 0px;
     animation: neon-flicker 4.5s infinite, neon-float 6s ease-in-out infinite;
     pointer-events: none;
 }
@@ -1264,7 +1265,7 @@ div.line-through {
     font-weight: 800;
     font-size: 24px;
     letter-spacing: 2px;
-    margin-left: 6px;
+    text-align: center;
     color: transparent;
     -webkit-text-stroke: 2px rgba(0, 255, 255, 0.9);
     text-shadow: 2px 2px 0 rgba(0, 140, 140, 0.65),
@@ -1277,9 +1278,8 @@ div.line-through {
     --arrow-rotate: 90deg;
     width: 88px;
     height: 8px;
-    margin-left: 12px;
     margin-top: -4px;
-    align-self: flex-start;
+    align-self: center;
     border-radius: 999px;
     background: linear-gradient(90deg, rgba(0, 255, 255, 0.35), rgba(0, 255, 255, 0.95), rgba(255, 0, 255, 0.85));
     display: block;
@@ -1336,10 +1336,10 @@ div.line-through {
 
 @keyframes neon-float {
     0%, 100% {
-        transform: translateY(0);
+        transform: translateX(var(--chat-sign-offset)) translateY(0);
     }
     50% {
-        transform: translateY(-6px);
+        transform: translateX(var(--chat-sign-offset)) translateY(-6px);
     }
 }
 
@@ -1353,9 +1353,30 @@ div.line-through {
 }
 
 .logo-container .top-line {
-    text-shadow: 0 0 8px rgba(0, 255, 255, 0.75),
-        0 0 16px rgba(255, 0, 255, 0.55),
-        0 0 26px rgba(0, 255, 255, 0.65);
+    font-family: 'Trebuchet MS', 'Segoe UI', sans-serif;
+    font-weight: 800;
+    color: transparent;
+    -webkit-text-stroke: 2px rgba(0, 160, 255, 0.95);
+    text-shadow: 2px 2px 0 rgba(0, 80, 160, 0.6),
+        0 0 12px rgba(0, 140, 255, 0.9),
+        0 0 26px rgba(0, 120, 255, 0.85),
+        0 0 40px rgba(0, 190, 255, 0.75);
+    animation: neon-flicker 4.5s infinite, neon-blue-pulse 3.2s ease-in-out infinite;
+}
+
+@keyframes neon-blue-pulse {
+    0%, 100% {
+        text-shadow: 2px 2px 0 rgba(0, 80, 160, 0.6),
+            0 0 12px rgba(0, 140, 255, 0.9),
+            0 0 26px rgba(0, 120, 255, 0.85),
+            0 0 40px rgba(0, 190, 255, 0.75);
+    }
+    50% {
+        text-shadow: 2px 2px 0 rgba(0, 100, 200, 0.7),
+            0 0 16px rgba(0, 180, 255, 0.95),
+            0 0 32px rgba(0, 140, 255, 0.9),
+            0 0 48px rgba(0, 210, 255, 0.85);
+    }
 }
 
 #language-btn {


### PR DESCRIPTION
### Motivation
- Center the neon "Let’s Talk!" sign (arrow) so it is always visually centered above the chat icon, and update the visible “SaaS” portion of the logo to match the neon styling of the chat sign (blue, flashing) while leaving "Productized Co" unchanged.

### Description
- Added dynamic positioning in `script.js` to compute the chat button center and position the `#chat-sign` accordingly, and repositions on window `resize` via a `positionChatSign` function. 
- Adjusted `#chat-sign` styles in `styles.css` to center-align the sign elements, introduced a `--chat-sign-offset` CSS variable, and updated the floating animation to apply the offset so the arrow remains centered over the icon during animations. 
- Centered and cleaned up `.chat-sign-text` and `.chat-sign-arrow` spacing so the arrow appears directly above the chat icon and removed left-margin-based alignment. 
- Restyled `.logo-container .top-line` (the "SaaS" text) with blue neon text stroke, neon flicker/pulse animation (`neon-blue-pulse`), and matching font weight/font-family so it visually matches the neon "Let’s Talk!" treatment while keeping the rest of the logo intact.

### Testing
- Launched a local HTTP server with `python -m http.server 8000` and confirmed the site served successfully. 
- Ran a Playwright script that loaded `http://127.0.0.1:8000/index.html` at `1400x900` and captured a full-page screenshot which completed and produced `artifacts/chat-logo-update.png` successfully. 
- No automated unit tests were added or failed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981a7ce69b883218d528400af30064f)