### PR TITLE
Fix chat sign alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/script.js
+++ b/script.js
@@ -212,9 +212,16 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const positionChatSign = () => {
         const chatRect = chatBtn.getBoundingClientRect();
+        const signRect = chatSign.getBoundingClientRect();
+        const signWidth = signRect.width || chatSign.offsetWidth;
         const centerX = chatRect.left + (chatRect.width / 2);
-        chatSign.style.left = `${centerX}px`;
-        chatSign.style.setProperty('--chat-sign-offset', '-50%');
+        const desiredLeft = centerX - (signWidth / 2);
+        const gutter = 12;
+        const maxLeft = window.innerWidth - signWidth - gutter;
+        const clampedLeft = Math.min(Math.max(desiredLeft, gutter), maxLeft);
+
+        chatSign.style.left = `${clampedLeft}px`;
+        chatSign.style.setProperty('--chat-sign-offset', '0px');
     };
     positionChatSign();
     window.addEventListener('resize', positionChatSign);


### PR DESCRIPTION
### Motivation
- The neon "Let’s Talk" sign was positioned too far left and could be cut off at small viewports, so it needs to be centered above the chat icon and clamped inside the viewport.

### Description
- Update `positionChatSign` in `script.js` to compute the sign width and set a `desiredLeft` centered over the chat button, then clamp the left value between a small `gutter` and the viewport right edge. 
- Apply the clamped left value to `chatSign.style.left` and set `--chat-sign-offset` to `0px` to avoid additional shifts.
- Add a `.gitignore` containing `node_modules/` to keep dependencies out of version control.

### Testing
- Launched the app with `node server.js` and the server started and listened on port 3000. (succeeded)
- Ran a Playwright script that opened `http://127.0.0.1:3000/` at `1440x900` and saved a screenshot to `artifacts/chat-sign-alignment.png` to visually verify alignment. (succeeded)
- No unit tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981a93e904c83219b930c7873c46617)